### PR TITLE
Make the `Y_init` parameter work

### DIFF
--- a/R/densne.R
+++ b/R/densne.R
@@ -89,7 +89,7 @@ densne <- function(
         theta = theta,
         verbose = verbose,
         max_iter = max_iter,
-        Y_in = matrix(),
+        Y_in = if (is.null(Y_init)) matrix() else Y_init,
         init = !is.null(Y_init),
         stop_lying_iter = stop_lying_iter,
         mom_switch_iter = mom_switch_iter,

--- a/src/densvis.cpp
+++ b/src/densvis.cpp
@@ -55,7 +55,7 @@ Rcpp::NumericMatrix densne_cpp(
     no_dims,
     perplexity,
     theta,
-    false,
+    init,
     max_iter,
     momentum,
     final_momentum,


### PR DESCRIPTION
As far as I can tell, the `Y_init` parameter isn't actually passed from `densne` to `densne_cpp`. Additionally, `densne_cpp` always passes `skip_random_init = false` to `DENSNE::run`, so `Y` is always overwritten with random values.

This pull request should hopefully make `Y_init` work as documented.